### PR TITLE
Update pypi URL

### DIFF
--- a/pip2pkgbuild/pip2pkgbuild.py
+++ b/pip2pkgbuild/pip2pkgbuild.py
@@ -33,8 +33,8 @@ logging.basicConfig(
 )
 LOG = logging.getLogger('log')
 
-MODULE_JSON = 'http://pypi.python.org/pypi/{name}/json'
-VERSION_MODULE_JSON = 'http://pypi.python.org/pypi/{name}/{version}/json'
+MODULE_JSON = 'https://pypi.python.org/pypi/{name}/json'
+VERSION_MODULE_JSON = 'https://pypi.python.org/pypi/{name}/{version}/json'
 
 MAINTINER_LINE = "# Maintainer: {name} <{email}>\n"
 


### PR DESCRIPTION
Pypi has changed it's behaviour, and will now return a http error 403 for plain http.