### PR TITLE
"403: SSL is required." from pypi API

### DIFF
--- a/pip2pkgbuild/pip2pkgbuild.py
+++ b/pip2pkgbuild/pip2pkgbuild.py
@@ -33,8 +33,8 @@ logging.basicConfig(
 )
 LOG = logging.getLogger('log')
 
-MODULE_JSON = 'http://pypi.python.org/pypi/{name}/json'
-VERSION_MODULE_JSON = 'http://pypi.python.org/pypi/{name}/{version}/json'
+MODULE_JSON = 'https://pypi.python.org/pypi/{name}/json'
+VERSION_MODULE_JSON = 'https://pypi.python.org/pypi/{name}/{version}/json'
 
 MAINTINER_LINE = "# Maintainer: {name} <{email}>\n"
 


### PR DESCRIPTION
```
curl -vvv http://pypi.python.org/pypi/numpy/json
*   Trying 151.101.8.223...
* TCP_NODELAY set
* Connected to pypi.python.org (151.101.8.223) port 80 (#0)
> GET /pypi/numpy/json HTTP/1.1
> Host: pypi.python.org
> User-Agent: curl/7.59.0
> Accept: */*
> 
< HTTP/1.1 403 SSL is required
< Server: Varnish
< Retry-After: 0
< Content-Type: text/plain; charset=UTF-8
< Content-Length: 16
< Accept-Ranges: bytes
< Date: Wed, 23 May 2018 17:18:57 GMT
< Connection: close
< X-Served-By: cache-hnd18734-HND
< X-Cache: MISS
< X-Cache-Hits: 0
< X-Timer: S1527095937.087602,VS0,VE0
< Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< X-Frame-Options: deny
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Permitted-Cross-Domain-Policies: none
< 
* Closing connection 0
SSL is required.
```
So plz switch to https.