### PR TITLE
updated SOURCE_TARGZ to match arch package guidelines

### DIFF
--- a/pip2pkgbuild/pip2pkgbuild.py
+++ b/pip2pkgbuild/pip2pkgbuild.py
@@ -54,7 +54,7 @@ source=("{source}")
 md5sums=('{checksums}')
 """
 
-SOURCE_TARGZ = "https://files.pythonhosted.org/packages/source/{init}/{module}/{_module}-${{pkgver}}.tar.gz"
+SOURCE_TARGZ = "https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz"
 
 PREPARE_FUNC = """\
 prepare() {
@@ -302,8 +302,7 @@ class PyModule(object):
         :rtype: str
         """
         if url.endswith('.tar.gz'):
-            l = SOURCE_TARGZ.format(
-                init=self.name[0], module=self.name, _module=self.module)
+            l = SOURCE_TARGZ
         else:
             l = url.replace(self.pkgver, "${pkgver}")
         return l


### PR DESCRIPTION
Updated generated PKGBUILD to more closely match [Python Package Guidelines](https://wiki.archlinux.org/index.php/Python_package_guidelines)

make2help
```
source=("https://files.pythonhosted.org/packages/source/m/make2help/make2help-${pkgver}.tar.gz")
```
becomes
```
source=("https://files.pythonhosted.org/packages/source/${_module::1}/$_module/$_module-$pkgver.tar.gz")

```