### PR TITLE
Update AUR installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,9 @@ Installation
 - Install from ``AUR``:
     .. code-block:: shell
 
-     $ yaourt -S pip2pkgbuild
+     $ git clone https://aur.archlinux.org/packages/pip2pkgbuild
+     $ cd pip2pkgbuild
+     $ makepkg -si
 
 - Install from ``PyPi``:
     .. code-block:: shell


### PR DESCRIPTION
The yaourt AUR helper is gone. Using git and makepkg is the official method, although the user could use another AUR helper.