### PR TITLE
Update license locations

### DIFF
--- a/pip2pkgbuild/__main__.py
+++ b/pip2pkgbuild/__main__.py
@@ -1,4 +1,4 @@
 from .pip2pkgbuild import main
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import os
 from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-META = imp.load_source('', os.path.join(here, 'pip2pkgbuild/pip2pkgbuild.py')).META
+META = imp.load_source('',
+                       os.path.join(here, 'pip2pkgbuild/pip2pkgbuild.py')).META
 with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = os.linesep + f.read()
 
@@ -14,7 +15,7 @@ setup(
     version=META['version'],
     description=META['description'],
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
 
     url='https://github.com/wenLiangcan/pip2pkgbuild',
     author='wenLiangcan',


### PR DESCRIPTION
Since [RFC16](https://rfc.archlinux.page/0016-spdx-license-identifiers/), known license locations have been shuffled a bit.

This also adds (commented-out) a function to get the common licenses (which don't need to be installed per-project), in case we later want to either skip such licenses, or warn if no license file could be found for an uncommon license